### PR TITLE
Don't sync issue labels for repositories which have issues disabled

### DIFF
--- a/lib/commands/issueLabels.js
+++ b/lib/commands/issueLabels.js
@@ -41,7 +41,7 @@ commandRunner(async () => {
     let allGithubRepositories = await client.fetchAllResults(client.github.repos.getForOrg, {
         org: githubOrg.login,
     });
-    allGithubRepositories = allGithubRepositories.filter(repository => !repository.archived);
+    allGithubRepositories = allGithubRepositories.filter(repository => !repository.archived && repository.has_issues);
     console.log(`\t${allGithubRepositories.length} active repositories found`);
 
     // Update the issue labels of all repositories


### PR DESCRIPTION
This prevents the label sync from crashing when it encounters a repository for which issue tracking is not enabled.