### PR TITLE
Support repository-specific issue labels

### DIFF
--- a/lib/commands/issueLabels.js
+++ b/lib/commands/issueLabels.js
@@ -53,8 +53,12 @@ commandRunner(async () => {
             repo: githubRepository.name,
         });
 
+        // Use repository-configured issue labels, or, if those are not specified, the global issue label configuration
+        const repositoryConfig = config.repositories.find(repository => repository.name === githubRepository.name);
+        const expectedIssueLabels = (repositoryConfig && repositoryConfig.issueLabels) || config.issueLabels;
+
         // Add new labels
-        const labelsToAdd = config.issueLabels.filter(issueLabel => !repoLabels.find(label => label.name.toLowerCase() === issueLabel.name.toLowerCase()));
+        const labelsToAdd = expectedIssueLabels.filter(issueLabel => !repoLabels.find(label => label.name.toLowerCase() === issueLabel.name.toLowerCase()));
         await Promise.all(labelsToAdd.map(async (newLabel) => {
             console.log(`\tAdding new label '${newLabel.name}' with color '#${newLabel.color}'...`);
 
@@ -69,7 +73,7 @@ commandRunner(async () => {
 
         // Update changed labels (only color can change)
         await Promise.all(repoLabels.map(async (repoLabel) => {
-            const issueLabel = config.issueLabels.find(label => label.name.toLowerCase() === repoLabel.name.toLowerCase());
+            const issueLabel = expectedIssueLabels.find(label => label.name.toLowerCase() === repoLabel.name.toLowerCase());
             if (!issueLabel) {
                 return null;
             }
@@ -93,7 +97,7 @@ commandRunner(async () => {
         }));
 
         // Delete obsolete labels
-        const repoLabelsToDelete = repoLabels.filter(repoLabel => !config.issueLabels.find(label => label.name.toLowerCase() === repoLabel.name.toLowerCase()));
+        const repoLabelsToDelete = repoLabels.filter(repoLabel => !expectedIssueLabels.find(label => label.name.toLowerCase() === repoLabel.name.toLowerCase()));
         await Promise.all(repoLabelsToDelete.map(async (repoLabel) => {
             console.log(`\tDeleting label '${repoLabel.name}'...`);
 

--- a/lib/configReader.js
+++ b/lib/configReader.js
@@ -286,6 +286,18 @@ module.exports = async (filePath) => {
             teamPermission.permission = parsePermissionString(teamPermission.permission);
         });
     });
+    config.repositories.forEach((repository) => {
+        if (repository.issueLabels && repository.additionalIssueLabels) {
+            throw new Error(`Invalid config: '${repository.name}' must not specify both 'issueLabels' and 'additionalIssueLabels'`);
+        }
+        if (repository.issueLabels) {
+            repository.issueLabels.forEach(validateIssueLabel);
+        }
+        if (repository.additionalIssueLabels) {
+            repository.additionalIssueLabels.forEach(validateIssueLabel);
+            repository.issueLabels = [...config.issueLabels, ...repository.additionalIssueLabels];
+        }
+    });
     config.issueLabels.forEach((label) => {
         label.color = label.color.toLowerCase();
     });


### PR DESCRIPTION
This PR allows specifying issue labels at the repository level.

The first option is to add the `additionalIssueLabels` key in the repository's configuration:

```yaml
repositories:
    - name: my-repo
      additionalIssueLabels:
          - name: clarification needed
            description: 'Something is not quite clear'
            color: 00ff00
          - name: spec needed
            description: 'A user story must be written before implementation can start'
            color: ff0000
```

If this option is used, these issue labels will be created in addition to those specified under the global `issueLabels` section.

The second option is to specify the entire list of issue labels for the project. For example, if a project should not have any issue labels at all, this can be accomplished like this:

```yaml
repositories:
    - name: my-repo
      issueLabels: []
```

Specifying both `issueLabels` and `additionalIssueLabels` at the repository level is considered a configuration error and will fail configuration validation.